### PR TITLE
Fix neo4j errors

### DIFF
--- a/NEO4J/snomed_g_graphdb_build_tools.py
+++ b/NEO4J/snomed_g_graphdb_build_tools.py
@@ -222,7 +222,7 @@ def db_build(arglist):
       'mode':['build','prep','make_csvs','validate']},
     {'stepname':'TEMPLATE_PROCESSING',    'cmd':'python %s/snomed_g_template_tools.py instantiate %s/snomed_g_graphdb_cypher_%s.template build.cypher --rf2 %s --release_type %s' % (snomed_g_bin,snomed_g_bin,('create' if opts.action=='create' else 'update'),opts.rf2,opts.release_type),
       'mode':['build','prep']},
-    {'stepname':'CYPHER_EXECUTION',       'cmd':'python %s/snomed_g_neo4j_tools.py run_cypher %s/build.cypher --verbose --neopw64 %s' % (snomed_g_bin, snomed_g_bin, opts.neopw64), 'mode':['build','run_cypher']},
+    {'stepname':'CYPHER_EXECUTION',       'cmd':'python %s/snomed_g_neo4j_tools.py run_cypher build.cypher --verbose --neopw64 %s' % (snomed_g_bin, opts.neopw64), 'mode':['build','run_cypher']},
     {'stepname':'CHECK_RESULT',           'cmd':'python %s/snomed_g_neo4j_tools.py run_cypher %s/snomed_g_graphdb_update_failure_check.cypher --verbose --neopw64 %s' % (snomed_g_bin, snomed_g_bin, opts.neopw64), 'mode':['build','run_cypher']},
     {'stepname':'JOB_END',                'log':'JOB-END'}
   ]

--- a/NEO4J/snomed_g_template_tools.py
+++ b/NEO4J/snomed_g_template_tools.py
@@ -108,7 +108,7 @@ def instantiate(arglist):
       load_csv_line = ('LOAD CSV with headers from "%s%sDR_%s_new.csv" as line' % (('file:///' if sys.platform in ['cygwin','win32','darwin'] else 'file:'),output_dir,typeId)).replace('file:////','file:///')
       print(load_csv_line,file=fout)
       print('with line, line.sctid as source_id, line.destinationId as dest_id, line.rolegroup as rolegroup_id',file=fout)
-      print('MERGE (rg:RoleGroup { sctid: source_id, rolegroup: rolegroup_id };)',file=fout)
+      print('MERGE (rg:RoleGroup { sctid: source_id, rolegroup: rolegroup_id });',file=fout)
       print(file=fout)
       print('// Add defining relationship edge in 2nd step, Java memory issue',file=fout)
       print('USING PERIODIC COMMIT 200',file=fout)


### PR DESCRIPTION
While attempting to use the Neo4j code to load a full snomed release, I ran into some runtime errors that were caused by a typo and an inconsistent input file path usage. I have fixed these two issues in this branch. 

TODO: The code raises some (InvalidValue) exceptions that are not defined, which will itself raise an exception whenever encountered. A definition should be added or a built-in exception should be used instead.