### PR TITLE
Update to readme and script related to MySQL version compatibility

### DIFF
--- a/mysql-loader-with-optimized-views/README.md
+++ b/mysql-loader-with-optimized-views/README.md
@@ -1,5 +1,12 @@
-# SNOMED CT MySQL Loader with Optimized Views
+# SNOMED CT MySQL 5.7 Loader with Optimized Views
 ## Using the SQL Loader
+
+## IMPORTANT NOTE
+
+The current version of the loader script has been tested to work with MySQL 5.7. However, it may not work with later versions without modification to the data loading process.
+
+Use with MySQL version 8.x requires changes to settings that are not yet fully documented. This is due to changes in default security provisions that block the "LOAD DATA LOCAL INFILE" statements. These statements are used to install the SNOMED CT release files into the database.
+Once the best way to work around these issues have been determined an update will be posted.
 
 ## Introduction
 

--- a/mysql-loader-with-optimized-views/rf2_load_InternationalRF2_PRODUCTION_20190131_relpath.sql
+++ b/mysql-loader-with-optimized-views/rf2_load_InternationalRF2_PRODUCTION_20190131_relpath.sql
@@ -4,6 +4,10 @@
 -- MySQL Script for Loading and Optimizing SNOMED CT Release Files
 -- Apache 2.0 license applies
 -- 
+-- MySQL VERSION NOTES: 
+--    Tested to work on MySQL 5.7
+--    Known issues with MySQL 8.x due to security blocking LOAD DATA LOCAL INFILE statements
+--
 -- =======================================================
 -- Copyright of this version 2018: SNOMED International www.snomed.org
 -- Based on work by David Markwell between 2011 and 2018


### PR DESCRIPTION
The changes to these files document security issue with MySQL 8.x which block the loader and advise use of 5.7 until the issue is resolved.